### PR TITLE
changed lambda role naming convention to include region

### DIFF
--- a/src/aws/iam-calls.ts
+++ b/src/aws/iam-calls.ts
@@ -169,9 +169,9 @@ export async function createOrUpdatePolicy(policyName: string, policyArn: string
 }
 
 export async function createOrUpdateRoleAndPolicy(roleName: string, trustedServices: string[], policyArn: string, policyDocument: any): Promise<AWS.IAM.Role | null> {
-    const role = await exports.createRoleIfNotExists(roleName, trustedServices);
+    await exports.createRoleIfNotExists(roleName, trustedServices);
     const policy = await exports.createOrUpdatePolicy(roleName, policyArn, policyDocument);
-    const policyAttachment = await exports.attachPolicyToRole(policy.Arn, roleName);
+    await exports.attachPolicyToRole(policy.Arn, roleName);
     return exports.getRole(roleName);
 }
 

--- a/src/common/deployers-common.ts
+++ b/src/common/deployers-common.ts
@@ -30,8 +30,8 @@ export async function uploadDirectoryToBucket(directoryToUpload: string, s3FileN
     return s3ObjectInfo;
 }
 
-export async function createLambdaCodePipelineRole(accountId: string): Promise<AWS.IAM.Role | null> {
-    const roleName = 'RockefellerLambdaRole';
+export async function createLambdaCodePipelineRole(accountId: string, region: string): Promise<AWS.IAM.Role | null> {
+    const roleName = `RockefellerLambdaRole-${region}`;
     const policyArn = `arn:aws:iam::${accountId}:policy/rockefeller/${roleName}`;
     const policyDocument = {
         Version: '2012-10-17',

--- a/src/phases/runscope/index.ts
+++ b/src/phases/runscope/index.ts
@@ -94,7 +94,7 @@ export async function deployPhase(phaseContext: PhaseContext<PhaseConfig>, accou
     let stack = await cloudformationCalls.getStack(STACK_NAME);
     if (!stack) {
         winston.info(`Creating Lambda function for Runscope tests`);
-        const role = await deployersCommon.createLambdaCodePipelineRole(accountConfig.account_id);
+        const role = await deployersCommon.createLambdaCodePipelineRole(accountConfig.account_id, accountConfig.region);
         if(!role) {
             throw new Error(`Runscope Lambda role could not be created`);
         }

--- a/src/phases/slack_notify/index.ts
+++ b/src/phases/slack_notify/index.ts
@@ -106,7 +106,7 @@ export async function deployPhase(phaseContext: PhaseContext<SlackNotifyConfig>,
     let stack = await cloudformationCalls.getStack(STACK_NAME);
     if (!stack) {
         winston.info(`Creating Lambda function for Slack notifications`);
-        const role = await deployersCommon.createLambdaCodePipelineRole(accountConfig.account_id);
+        const role = await deployersCommon.createLambdaCodePipelineRole(accountConfig.account_id, accountConfig.region);
         if(!role) {
             throw new Error(`Could not create role for Slack Notify lambda`);
         }

--- a/test/common/deployers-common-test.ts
+++ b/test/common/deployers-common-test.ts
@@ -57,13 +57,14 @@ describe('deployersCommon module', () => {
     describe('createLambdaCodePipelineRole', () => {
         it('should create the role for the Lambda', async () => {
             const accountId = '111111111111';
+            const region = 'us-west-2';
             const fakeArn = 'FakeArn';
 
             const createOrUpdateRoleStub = sandbox.stub(iamCalls, 'createOrUpdateRoleAndPolicy').resolves({
                 Arn: fakeArn
             });
 
-            const role = await deployersCommon.createLambdaCodePipelineRole(accountId);
+            const role = await deployersCommon.createLambdaCodePipelineRole(accountId, region);
             expect(role!.Arn).to.equal(fakeArn);
             expect(createOrUpdateRoleStub.callCount).to.equal(1);
         });


### PR DESCRIPTION
this is a change I have on handel-codepipeline as well, and I figured I should add it to rockefeller as well
